### PR TITLE
Add Random Event indicator to the overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A RuneLite plugin that displays your player stats in a floating overlay window t
 - **Special Attack**: Current percentage with color coding
 - **Inventory**: Used slots out of 28 with percentage
 - **Status**: Shows if you're Active or Idle
+- **Random Event**: Shows what random event (if any) is currently active
 - **Character Name**: Displays at the top of the overlay
 
 ### **Sound Notifications**

--- a/src/main/java/com/afkoverlay/AFKOverlayConfig.java
+++ b/src/main/java/com/afkoverlay/AFKOverlayConfig.java
@@ -297,11 +297,28 @@ default boolean showHp() { return true; }
     )
     default boolean playIdleSound() { return false; }
 
+    // --- Random Events Settings Section ---
+    @ConfigSection(
+        name = "Random Events",
+        description = "Display current random events.",
+        position = 60
+    )
+    String randomEventSection = "randomEventSection";
+
+    @ConfigItem(
+        keyName = "showRandomEvents",
+        name = "Show Random Events",
+        description = "Display current random event in the overlay.",
+        section = randomEventSection,
+        position = 1
+    )
+    default boolean showRandomEvents() { return true; }
+
     // --- Window Settings Section ---
     @ConfigSection(
         name = "General Settings",
         description = "Configure general settings.",
-        position = 60
+        position = 70
     )
     String windowSection = "windowSection";
 

--- a/src/main/java/com/afkoverlay/AFKOverlayPlugin.java
+++ b/src/main/java/com/afkoverlay/AFKOverlayPlugin.java
@@ -1,11 +1,15 @@
 package com.afkoverlay;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
+import net.runelite.api.events.InteractingChanged;
+import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.PlayerChanged;
+import net.runelite.api.gameval.NpcID;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
@@ -18,6 +22,8 @@ import javax.inject.Inject;
 import javax.swing.SwingUtilities;
 import java.awt.Image;
 import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @PluginDescriptor(
@@ -26,6 +32,32 @@ import java.time.Instant;
     tags = {"overlay", "player", "stats", "afk"}
 )
 public class AFKOverlayPlugin extends Plugin {
+
+    private static final Set<Integer> EVENT_NPCS = ImmutableSet.of(
+            NpcID.MACRO_BEEKEEPER_INVITATION,
+            NpcID.MACRO_COMBILOCK_PIRATE,
+            NpcID.MACRO_JEKYLL, NpcID.MACRO_JEKYLL_UNDERWATER,
+            NpcID.MACRO_DWARF,
+            NpcID.PATTERN_INVITATION,
+            NpcID.MACRO_EVIL_BOB_OUTSIDE, NpcID.MACRO_EVIL_BOB_PRISON,
+            NpcID.PINBALL_INVITATION,
+            NpcID.MACRO_FORESTER_INVITATION,
+            NpcID.MACRO_FROG_CRIER,
+            NpcID.MACRO_GENI, NpcID.MACRO_GENI_UNDERWATER,
+            NpcID.MACRO_GILES, NpcID.MACRO_GILES_UNDERWATER,
+            NpcID.MACRO_GRAVEDIGGER_INVITATION,
+            NpcID.MACRO_MILES, NpcID.MACRO_MILES_UNDERWATER,
+            NpcID.MACRO_MYSTERIOUS_OLD_MAN, NpcID.MACRO_MYSTERIOUS_OLD_MAN_UNDERWATER,
+            NpcID.MACRO_MAZE_INVITATION, NpcID.MACRO_MIME_INVITATION,
+            NpcID.MACRO_NILES, NpcID.MACRO_NILES_UNDERWATER,
+            NpcID.MACRO_PILLORY_GUARD,
+            NpcID.GRAB_POSTMAN,
+            NpcID.MACRO_MAGNESON_INVITATION,
+            NpcID.MACRO_HIGHWAYMAN, NpcID.MACRO_HIGHWAYMAN_UNDERWATER,
+            NpcID.MACRO_SANDWICH_LADY_NPC,
+            NpcID.MACRO_DRILLDEMON_INVITATION,
+            NpcID.MACRO_COUNTCHECK_SURFACE, NpcID.MACRO_COUNTCHECK_UNDERWATER
+    );
 
     @Inject
     private Client client;
@@ -51,6 +83,9 @@ public class AFKOverlayPlugin extends Plugin {
     private boolean windowClosedByUser = false;
     private Instant lastSoundPlayed = Instant.now();
     private static final int SOUND_ID = 3817;
+
+    private Optional<NPC> currentRandomEvent = Optional.empty();
+
 
     @Override
     protected void startUp() throws Exception {
@@ -109,6 +144,8 @@ public class AFKOverlayPlugin extends Plugin {
                 floatingWindow = null;
             });
         }
+
+        currentRandomEvent = Optional.empty();
     }
 
     @Subscribe
@@ -215,6 +252,8 @@ public class AFKOverlayPlugin extends Plugin {
         
         // Update protection prayer
         updateProtectionPrayer(player);
+
+        playerInfo.setCurrentRandomEvent(currentRandomEvent.map(NPC::getName).orElse(null));
 
         // Update the floating window
         if (floatingWindow != null && (previousPlayerInfo == null || !previousPlayerInfo.equals(playerInfo))) {
@@ -377,4 +416,39 @@ public class AFKOverlayPlugin extends Plugin {
             preferences.setSoundEffectVolume(previousVolume);
         }
     }
+
+    @Subscribe
+    public void onInteractingChanged(InteractingChanged event)
+    {
+        Actor source = event.getSource();
+        Actor target = event.getTarget();
+        Player player = client.getLocalPlayer();
+
+        // Check that the npc is interacting with the player and the player isn't interacting with the npc, so
+        // that the notification doesn't fire from talking to other user's randoms
+        if (player == null
+                || target != player
+                || player.getInteracting() == source
+                || !(source instanceof NPC)
+                || !EVENT_NPCS.contains(((NPC) source).getId()))
+        {
+            return;
+        }
+
+        log.debug("Random event spawn: {}", source.getName());
+
+        currentRandomEvent = Optional.of((NPC) source);
+    }
+
+    @Subscribe
+    public void onNpcDespawned(NpcDespawned npcDespawned)
+    {
+        NPC npc = npcDespawned.getNpc();
+
+        if (currentRandomEvent.isPresent() && npc == currentRandomEvent.get())
+        {
+            currentRandomEvent = Optional.empty();
+        }
+    }
+
 }

--- a/src/main/java/com/afkoverlay/FloatingOverlayWindow.java
+++ b/src/main/java/com/afkoverlay/FloatingOverlayWindow.java
@@ -59,6 +59,7 @@ public class FloatingOverlayWindow extends JFrame {
     private JLabel statusLabel;
     private JLabel inventoryLabel;
     private JLabel specialAttackLabel;
+    private JLabel randomEventLabel;
     private JPanel titleBar;
     private JLabel characterNameLabel;
     private Window runeliteWindow;
@@ -191,6 +192,7 @@ public class FloatingOverlayWindow extends JFrame {
         statusLabel = createLabel("Status: ACTIVE", null);
         inventoryLabel = createLabel("", inventoryIcon);
         specialAttackLabel = createLabel("", specialAttackIcon);
+        randomEventLabel = createLabel("", null);
     }
     
     private void setupLayout() {
@@ -205,6 +207,7 @@ public class FloatingOverlayWindow extends JFrame {
         addComponentIfVisible(config.showInventory(), inventoryLabel);
         addComponentIfVisible(config.showSpecialAttack(), specialAttackLabel);
         addComponentIfVisible(config.showStatus(), statusLabel);
+        addComponentIfVisible(config.showRandomEvents(), randomEventLabel);
         
         contentPanel.add(infoPanel, BorderLayout.CENTER);
         
@@ -571,6 +574,7 @@ public class FloatingOverlayWindow extends JFrame {
         statusLabel.setVisible(config.showStatus());
         inventoryLabel.setVisible(config.showInventory());
         specialAttackLabel.setVisible(config.showSpecialAttack());
+        randomEventLabel.setVisible(config.showRandomEvents());
         
         // Rebuild info panel
         rebuildInfoPanel();
@@ -595,7 +599,8 @@ public class FloatingOverlayWindow extends JFrame {
         addComponentIfVisible(config.showInventory(), inventoryLabel);
         addComponentIfVisible(config.showSpecialAttack(), specialAttackLabel);
         addComponentIfVisible(config.showStatus(), statusLabel);
-        
+        addComponentIfVisible(config.showRandomEvents(), randomEventLabel);
+
         contentPanel.add(infoPanel, BorderLayout.CENTER);
     }
     
@@ -606,6 +611,7 @@ public class FloatingOverlayWindow extends JFrame {
         inventoryLabel.setForeground(Constants.DARK_TEXT_COLOR);
         specialAttackLabel.setForeground(Constants.DARK_TEXT_COLOR);
         characterNameLabel.setForeground(Constants.DARK_TEXT_COLOR);
+        randomEventLabel.setForeground(Constants.DARK_TEXT_COLOR);
     }
     
     private void ensureMinimumDimensions() {
@@ -722,11 +728,12 @@ private void loadIcons() {
     public void updateDisplay() {
         SwingUtilities.invokeLater(() -> {
             updateHpDisplay();
-    updatePrayerDisplay();
-    updateStatusDisplay();
-    updateInventoryDisplay();
-    updateSpecialAttackDisplay();
-    contentPanel.repaint();
+            updatePrayerDisplay();
+            updateStatusDisplay();
+            updateInventoryDisplay();
+            updateSpecialAttackDisplay();
+            updateRandomEventDisplay();
+            contentPanel.repaint();
         });
     }
     
@@ -780,6 +787,18 @@ private void loadIcons() {
             specialAttackLabel.setText(playerInfo.getSpecialAttackText());
             int specPercent = playerInfo.getSpecialAttackEnergyPercentage();
             specialAttackLabel.setForeground(getColorForPercentage(specPercent, Constants.DARK_TEXT_COLOR));
+        }
+    }
+
+    private void updateRandomEventDisplay() {
+        if (config.showRandomEvents()) {
+            if (playerInfo.getCurrentRandomEvent() != null) {
+                randomEventLabel.setText("Event: " + playerInfo.getCurrentRandomEvent());
+                randomEventLabel.setForeground(Constants.ACTIVE_COLOR);
+            } else {
+                randomEventLabel.setText("Event: None");
+                randomEventLabel.setForeground(Constants.IDLE_COLOR);
+            }
         }
     }
     
@@ -848,7 +867,8 @@ private void loadIcons() {
         updateLabelSize(config.showStatus(), statusLabel, newFont, null, iconSize);
         updateLabelSize(config.showInventory(), inventoryLabel, newFont, inventoryIcon, iconSize);
         updateLabelSize(config.showSpecialAttack(), specialAttackLabel, newFont, specialAttackIcon, iconSize);
-        
+        updateLabelSize(config.showRandomEvents(), randomEventLabel, newFont, null, iconSize);
+
         // Update character name label
         characterNameLabel.setFont(new Font("Arial", Font.BOLD, fontSize));
         

--- a/src/main/java/com/afkoverlay/PlayerInfo.java
+++ b/src/main/java/com/afkoverlay/PlayerInfo.java
@@ -28,6 +28,7 @@ public class PlayerInfo {
     private int specialAttackEnergy = 0;
     private String characterName = "";
     private String activeProtectionPrayer = ""; // "melee", "magic", "ranged", or empty string
+    private String currentRandomEvent = "";
 
     public int getHpPercentage() {
         if (maxHp == 0) return 0;
@@ -51,17 +52,17 @@ public class PlayerInfo {
         return String.format("%d/%d (%d%%)", currentPrayer, maxPrayer, getPrayerPercentage());
     }
 
-public String getInventoryText() {
-    int totalSlots = 28;
-    int usagePercentage = (inventoryUsedSlots * 100) / totalSlots;
-    return String.format("%d/28 (%d%%)", inventoryUsedSlots, usagePercentage);
-}
+    public String getInventoryText() {
+        int totalSlots = 28;
+        int usagePercentage = (inventoryUsedSlots * 100) / totalSlots;
+        return String.format("%d/28 (%d%%)", inventoryUsedSlots, usagePercentage);
+    }
 
-public int getSpecialAttackEnergyPercentage() {
-    return specialAttackEnergy;
-}
+    public int getSpecialAttackEnergyPercentage() {
+        return specialAttackEnergy;
+    }
 
-public String getSpecialAttackText() {
+    public String getSpecialAttackText() {
     return String.format("%d%%", specialAttackEnergy);
 }
     


### PR DESCRIPTION
Implements #13 

Allows the current random event to be displayed in the overlay.

<img width="340" height="160" alt="Screenshot 2025-09-09 at 16 06 31" src="https://github.com/user-attachments/assets/b16f8d7c-9feb-4177-ae4a-90322b730d29" />

<img width="347" height="183" alt="Screenshot 2025-09-09 at 16 05 15" src="https://github.com/user-attachments/assets/1b07dc7e-f4c3-4981-97d8-a691141b58e9" />
