### PR TITLE
Add enemy health display to overlay

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,22 @@ tasks.withType(JavaCompile).configureEach {
 	options.release.set(11)
 }
 
+task runClient(type: JavaExec) {
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = 'com.afkoverlay.AFKOverlayPluginTest'
+	jvmArgs = [
+		'-ea',
+		'-Xmx768m',
+		'-Xss2m',
+		'-Dsun.java2d.metal=false',
+		'-Dsun.java2d.opengl=true',
+		'-Dapple.awt.application.appearance=system',
+		'--add-opens=java.base/java.net=ALL-UNNAMED',
+		'--add-opens=java.base/java.io=ALL-UNNAMED',
+		'--add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED'
+	]
+}
+
 tasks.register('shadowJar', Jar) {
 	dependsOn configurations.testRuntimeClasspath
 	manifest {

--- a/src/main/java/com/afkoverlay/AFKOverlayConfig.java
+++ b/src/main/java/com/afkoverlay/AFKOverlayConfig.java
@@ -242,6 +242,23 @@ default boolean showHp() { return true; }
     )
     default boolean playInvSound() { return false; }
 
+    // --- Enemy Health Section ---
+    @ConfigSection(
+        name = "Enemy Health",
+        description = "Show current target's health.",
+        position = 47
+    )
+    String enemyHealthSection = "enemyHealthSection";
+
+    @ConfigItem(
+        keyName = "showEnemyHealth",
+        name = "Show Enemy Health",
+        description = "Display the current target's health percentage in the overlay.",
+        section = enemyHealthSection,
+        position = 1
+    )
+    default boolean showEnemyHealth() { return true; }
+
     // --- Status Section ---
     @ConfigSection(
         name = "Status",

--- a/src/main/java/com/afkoverlay/AFKOverlayPlugin.java
+++ b/src/main/java/com/afkoverlay/AFKOverlayPlugin.java
@@ -147,7 +147,8 @@ public class AFKOverlayPlugin extends Plugin {
                 (event.getKey().equals("showHp") || 
                 event.getKey().equals("showPrayer") || 
                 event.getKey().equals("showStatus") || 
-                event.getKey().equals("showInventory"))) {
+                event.getKey().equals("showInventory") ||
+                event.getKey().equals("showEnemyHealth"))) {
                 if (floatingWindow != null) {
                     SwingUtilities.invokeLater(() -> floatingWindow.updateConfig());
                 }
@@ -215,6 +216,9 @@ public class AFKOverlayPlugin extends Plugin {
         
         // Update protection prayer
         updateProtectionPrayer(player);
+
+        // Update enemy health
+        updateEnemyHealth(player);
 
         // Update the floating window
         if (floatingWindow != null && (previousPlayerInfo == null || !previousPlayerInfo.equals(playerInfo))) {
@@ -309,6 +313,31 @@ public class AFKOverlayPlugin extends Plugin {
         
         playerInfo.setActiveProtectionPrayer(activePrayer);
         log.debug("Protection prayer: {}", activePrayer);
+    }
+
+    private void updateEnemyHealth(Player player) {
+        Actor target = player.getInteracting();
+        if (target instanceof NPC) {
+            NPC npc = (NPC) target;
+            String name = npc.getName();
+            int ratio = npc.getHealthRatio();
+            int scale = npc.getHealthScale();
+
+            if (name != null && ratio >= 0 && scale > 0) {
+                int healthPercent = (ratio * 100) / scale;
+                playerInfo.setEnemyName(name);
+                playerInfo.setEnemyHealthPercent(healthPercent);
+            } else if (name != null) {
+                // Target exists but no health bar visible yet
+                playerInfo.setEnemyName(name);
+            } else {
+                playerInfo.setEnemyName("");
+                playerInfo.setEnemyHealthPercent(-1);
+            }
+        } else {
+            playerInfo.setEnemyName("");
+            playerInfo.setEnemyHealthPercent(-1);
+        }
     }
 
     @Provides

--- a/src/main/java/com/afkoverlay/FloatingOverlayWindow.java
+++ b/src/main/java/com/afkoverlay/FloatingOverlayWindow.java
@@ -59,6 +59,7 @@ public class FloatingOverlayWindow extends JFrame {
     private JLabel statusLabel;
     private JLabel inventoryLabel;
     private JLabel specialAttackLabel;
+    private JLabel enemyHealthLabel;
     private JPanel titleBar;
     private JLabel characterNameLabel;
     private Window runeliteWindow;
@@ -191,6 +192,7 @@ public class FloatingOverlayWindow extends JFrame {
         statusLabel = createLabel("Status: ACTIVE", null);
         inventoryLabel = createLabel("", inventoryIcon);
         specialAttackLabel = createLabel("", specialAttackIcon);
+        enemyHealthLabel = createLabel("", null);
     }
     
     private void setupLayout() {
@@ -204,10 +206,11 @@ public class FloatingOverlayWindow extends JFrame {
         addComponentIfVisible(config.showPrayer(), prayerLabel);
         addComponentIfVisible(config.showInventory(), inventoryLabel);
         addComponentIfVisible(config.showSpecialAttack(), specialAttackLabel);
+        addComponentIfVisible(config.showEnemyHealth(), enemyHealthLabel);
         addComponentIfVisible(config.showStatus(), statusLabel);
-        
+
         contentPanel.add(infoPanel, BorderLayout.CENTER);
-        
+
         // Create title bar
         titleBar = createTitleBar();
         contentPanel.add(titleBar, BorderLayout.NORTH);
@@ -571,7 +574,8 @@ public class FloatingOverlayWindow extends JFrame {
         statusLabel.setVisible(config.showStatus());
         inventoryLabel.setVisible(config.showInventory());
         specialAttackLabel.setVisible(config.showSpecialAttack());
-        
+        enemyHealthLabel.setVisible(config.showEnemyHealth());
+
         // Rebuild info panel
         rebuildInfoPanel();
         
@@ -594,8 +598,9 @@ public class FloatingOverlayWindow extends JFrame {
         addComponentIfVisible(config.showPrayer(), prayerLabel);
         addComponentIfVisible(config.showInventory(), inventoryLabel);
         addComponentIfVisible(config.showSpecialAttack(), specialAttackLabel);
+        addComponentIfVisible(config.showEnemyHealth(), enemyHealthLabel);
         addComponentIfVisible(config.showStatus(), statusLabel);
-        
+
         contentPanel.add(infoPanel, BorderLayout.CENTER);
     }
     
@@ -605,6 +610,7 @@ public class FloatingOverlayWindow extends JFrame {
         statusLabel.setForeground(Constants.DARK_TEXT_COLOR);
         inventoryLabel.setForeground(Constants.DARK_TEXT_COLOR);
         specialAttackLabel.setForeground(Constants.DARK_TEXT_COLOR);
+        enemyHealthLabel.setForeground(Constants.DARK_TEXT_COLOR);
         characterNameLabel.setForeground(Constants.DARK_TEXT_COLOR);
     }
     
@@ -726,6 +732,7 @@ private void loadIcons() {
     updateStatusDisplay();
     updateInventoryDisplay();
     updateSpecialAttackDisplay();
+    updateEnemyHealthDisplay();
     contentPanel.repaint();
         });
     }
@@ -772,6 +779,26 @@ private void loadIcons() {
             inventoryLabel.setText(playerInfo.getInventoryText());
             int invPercent = (playerInfo.getInventoryUsedSlots() * 100) / 28;
             inventoryLabel.setForeground(getColorForPercentage(invPercent, Constants.DARK_TEXT_COLOR));
+        }
+    }
+
+    private void updateEnemyHealthDisplay() {
+        if (config.showEnemyHealth()) {
+            if (playerInfo.hasEnemyTarget()) {
+                enemyHealthLabel.setText(playerInfo.getEnemyHealthText());
+                int hp = playerInfo.getEnemyHealthPercent();
+                if (hp <= 10) {
+                    enemyHealthLabel.setForeground(Constants.DANGER_COLOR);
+                } else if (hp <= 50) {
+                    enemyHealthLabel.setForeground(Constants.WARNING_COLOR);
+                } else {
+                    enemyHealthLabel.setForeground(Constants.HP_COLOR);
+                }
+                enemyHealthLabel.setVisible(true);
+            } else {
+                enemyHealthLabel.setText("");
+                enemyHealthLabel.setVisible(false);
+            }
         }
     }
 
@@ -848,7 +875,8 @@ private void loadIcons() {
         updateLabelSize(config.showStatus(), statusLabel, newFont, null, iconSize);
         updateLabelSize(config.showInventory(), inventoryLabel, newFont, inventoryIcon, iconSize);
         updateLabelSize(config.showSpecialAttack(), specialAttackLabel, newFont, specialAttackIcon, iconSize);
-        
+        updateLabelSize(config.showEnemyHealth(), enemyHealthLabel, newFont, null, iconSize);
+
         // Update character name label
         characterNameLabel.setFont(new Font("Arial", Font.BOLD, fontSize));
         
@@ -900,6 +928,7 @@ private void loadIcons() {
         if (config.showPrayer()) componentCount++;
         if (config.showInventory()) componentCount++;
         if (config.showSpecialAttack()) componentCount++;
+        if (config.showEnemyHealth()) componentCount++;
         if (config.showStatus()) componentCount++;
         
         // Each component needs space for itself plus spacing

--- a/src/main/java/com/afkoverlay/PlayerInfo.java
+++ b/src/main/java/com/afkoverlay/PlayerInfo.java
@@ -17,6 +17,8 @@ public class PlayerInfo {
         this.specialAttackEnergy = other.specialAttackEnergy;
         this.characterName = other.characterName;
         this.activeProtectionPrayer = other.activeProtectionPrayer;
+        this.enemyName = other.enemyName;
+        this.enemyHealthPercent = other.enemyHealthPercent;
     }
 
     private int currentHp = 0;
@@ -28,6 +30,8 @@ public class PlayerInfo {
     private int specialAttackEnergy = 0;
     private String characterName = "";
     private String activeProtectionPrayer = ""; // "melee", "magic", "ranged", or empty string
+    private String enemyName = "";
+    private int enemyHealthPercent = -1; // -1 means no target
 
     public int getHpPercentage() {
         if (maxHp == 0) return 0;
@@ -71,5 +75,16 @@ public String getSpecialAttackText() {
     
     public void setActiveProtectionPrayer(String prayer) {
         this.activeProtectionPrayer = prayer;
+    }
+
+    public String getEnemyHealthText() {
+        if (enemyHealthPercent < 0 || enemyName.isEmpty()) {
+            return "";
+        }
+        return String.format("%s: %d%%", enemyName, enemyHealthPercent);
+    }
+
+    public boolean hasEnemyTarget() {
+        return enemyHealthPercent >= 0 && !enemyName.isEmpty();
     }
 }


### PR DESCRIPTION
## Summary

Adds a new **Enemy Health** row to the floating overlay that shows the current combat target's name and health percentage.

## Features

- Tracks the player's current combat target via `player.getInteracting()`
- Displays NPC name and health % (e.g. "Goblin: 75%")
- Color-coded: red when ≤10%, orange when ≤50%, light red otherwise
- Auto-hides when not targeting anything
- Togglable via **Show Enemy Health** in the Enemy Health config section
- Enabled by default

## Changes

- `PlayerInfo.java` — Added `enemyName`, `enemyHealthPercent` fields with helper methods
- `AFKOverlayConfig.java` — Added Enemy Health config section with show toggle
- `AFKOverlayPlugin.java` — Added `updateEnemyHealth()` using NPC health ratio/scale
- `FloatingOverlayWindow.java` — Added enemy health label, display update, and sizing
- `build.gradle` — Added `runClient` task for dev mode testing

## Screenshots

The enemy health row appears between Special Attack and Status when in combat, and hides automatically when not targeting an NPC.