### PR TITLE
Add option to mute idle sound when RuneLite is focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A RuneLite plugin that displays your player stats in a floating overlay window t
 ### Sounds
 - **Sound Volume**: Adjust the volume of the sound notifications.
 - **Play sound when threshold reached**: Individual toggles for HP, Prayer, Special Attack, Inventory, and Idle status.
+- **Mute idle sound when focused**: Suppress the idle sound while the RuneLite window is focused, so it only alerts you once you have tabbed away.
 
 ## Usage
 

--- a/src/main/java/com/afkoverlay/AFKOverlayConfig.java
+++ b/src/main/java/com/afkoverlay/AFKOverlayConfig.java
@@ -297,6 +297,15 @@ default boolean showHp() { return true; }
     )
     default boolean playIdleSound() { return false; }
 
+    @ConfigItem(
+        keyName = "muteIdleSoundWhenFocused",
+        name = "Mute idle sound when focused",
+        description = "Do not play the idle sound while the RuneLite window is focused.",
+        section = statusSection,
+        position = 6
+    )
+    default boolean muteIdleSoundWhenFocused() { return false; }
+
     // --- Window Settings Section ---
     @ConfigSection(
         name = "General Settings",

--- a/src/main/java/com/afkoverlay/AFKOverlayPlugin.java
+++ b/src/main/java/com/afkoverlay/AFKOverlayPlugin.java
@@ -311,6 +311,15 @@ public class AFKOverlayPlugin extends Plugin {
         return configManager.getConfig(AFKOverlayConfig.class);
     }
 
+    /**
+     * Returns true when a RuneLite window (the game client or the overlay) is the
+     * currently focused window of this JVM, meaning the user is actively looking
+     * at RuneLite rather than another application.
+     */
+    private boolean isRuneLiteFocused() {
+        return java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow() != null;
+    }
+
     private void checkThresholdsAndPlaySounds() {
         if (client.getGameState() != GameState.LOGGED_IN) {
             return;
@@ -359,7 +368,8 @@ public class AFKOverlayPlugin extends Plugin {
         }
 
         // Check Idle Status
-        if (config.playIdleSound() && playerInfo.isIdle()) {
+        if (config.playIdleSound() && playerInfo.isIdle()
+                && !(config.muteIdleSoundWhenFocused() && isRuneLiteFocused())) {
             playSound = true;
         }
 


### PR DESCRIPTION
## What

Adds a new Status-section config toggle: **"Mute idle sound when focused"** (default off).

When enabled, the idle sound is suppressed while a RuneLite window (the game client or the floating overlay) is the OS-active window. The idle alert then only fires once you have tabbed away to another application, which is the typical reason you want an idle reminder in the first place.

## Why

The idle sound currently plays whenever you are idle, even while you are actively looking at RuneLite. This option lets the alert stay quiet when you are present and only notify you when you have switched away.

## How

- `AFKOverlayConfig.muteIdleSoundWhenFocused()` added to the Status section (position 6), defaulting to `false` so existing behavior is unchanged.
- `AFKOverlayPlugin.checkThresholdsAndPlaySounds()` gates only the idle-sound branch on the new option.
- Focus is detected with `KeyboardFocusManager.getActiveWindow() != null`, so no new dependencies are introduced.

Only the idle sound is affected; HP, Prayer, Special Attack, and Inventory sounds are unchanged. `./gradlew compileJava` passes.